### PR TITLE
load hdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 .CondaPkg
 .vscode
 *.png
+.qodo
+*.hdf

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,11 +1,11 @@
-# Don't forget to run
-#
-#     pkg> dev ..
-#
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
+DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
 UnpackSinTiles = "017367d4-aa44-5400-a2e3-1f6255c9d3f1"
 
-[compat]
-Documenter = "1"
+[sources]
+UnpackSinTiles = {path = ".."}

--- a/docs/example.jl
+++ b/docs/example.jl
@@ -1,0 +1,21 @@
+using UnpackSinTiles
+using Rasters
+using GLMakie
+
+# https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MYD11C1/2024/001/
+# https://e4ftl01.cr.usgs.gov/MOLA/MYD11C1.061/2024.12.31/
+
+# hdf_path = joinpath(@__DIR__, "MYD11C1.A2024001.061.2024005085414.hdf")
+hdf_path = joinpath(@__DIR__, "MYD11C1.A2024366.061.2025003174450.hdf")
+hdf = open_hdf(hdf_path)
+
+_keys = get_hdf_keys(hdf)
+
+meta = parse_metadata(hdf)
+
+# Load the LST data
+lst = load_hdf_variable(hdf, "LST_Day_CMG")
+lst_32 = Float32.(lst)
+ras = Raster(lst_32, (Y, X))
+
+heatmap(ras)

--- a/src/UnpackSinTiles.jl
+++ b/src/UnpackSinTiles.jl
@@ -8,9 +8,10 @@ module UnpackSinTiles
     using Dates
     using SparseArrays
 
-    hdf(f) = @pyconst(pyimport("pyhdf.SD").SD)(f)
-    export hdf
+    open_hdf(f) = @pyconst(pyimport("pyhdf.SD").SD)(f)
+    export open_hdf
 
+    include("loadhdf.jl")
     include("loadTile.jl")
     include("metadata.jl")
     include("pixelOperations.jl")

--- a/src/loadTile.jl
+++ b/src/loadTile.jl
@@ -24,7 +24,7 @@ end
 function openTile(tile, in_date, root_path)
     full_path = getTilePath(tile, in_date, root_path)
     if !isnothing(full_path)
-        return hdf(full_path)
+        return open_hdf(full_path)
     else
         return nothing
     end

--- a/src/loadhdf.jl
+++ b/src/loadhdf.jl
@@ -1,0 +1,33 @@
+export get_hdf_keys
+export load_hdf_variable
+
+"""
+    get_hdf_keys(hdf)
+
+This function retrieves the keys of the datasets in the HDF file.
+# Arguments
+- hdf: HDF file object
+"""
+function get_hdf_keys(hdf)
+    pyKeys = hdf.datasets().keys()
+    return ["$k" for k in pyKeys]
+end
+
+"""
+    load_hdf_variable(hdf, variable; close_file = true)
+
+This function retrieves the specified variable from the HDF file and converts it to a Julia array.
+
+# Arguments
+- hdf: HDF file object
+- variable: Name of the variable to load
+- close_file: Whether to close the HDF file after loading (default: true)
+"""
+function load_hdf_variable(hdf, variable; close_file = true)
+    hdf_data = hdf.select(variable).get()
+    if close_file
+        hdf.end() # close hdf tile
+    end
+    hdf_data_jl = pyconvert(Array, hdf_data)
+    return hdf_data_jl
+end


### PR DESCRIPTION
basic load function. 

@meggart I had been using this in the past to read all MODIS related files, not supported by ArchGDAL.jl. The package is not clean at all but it does the job, see plenty of workflows in the test folder. 

If you have source (links?) for `hdf` files that I can use as tests directly, that would be great. `MODIS` sinusoidal tiles or else, should do, so that I can adapt some of the workflows for docs. 